### PR TITLE
Show service container logs when tearing down services

### DIFF
--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -338,12 +338,16 @@ namespace GitHub.Runner.Worker
 
             if (!string.IsNullOrEmpty(container.ContainerId))
             {
-                executionContext.Output($"Print container logs: {container.ContainerDisplayName}");
-
-                int logsExitCode = await _dockerManager.DockerLogs(executionContext, container.ContainerId);
-                if (logsExitCode != 0)
+                if(!container.IsJobContainer)
                 {
-                    executionContext.Warning($"Docker logs fail with exit code {logsExitCode}");
+                    // Print logs for service container jobs (not the "action" job itself b/c that's already logged).
+                    executionContext.Output($"Print service container logs: {container.ContainerDisplayName}");
+                    
+                    int logsExitCode = await _dockerManager.DockerLogs(executionContext, container.ContainerId);
+                    if (logsExitCode != 0)
+                    {
+                        executionContext.Warning($"Docker logs fail with exit code {logsExitCode}");
+                    }
                 }
 
                 executionContext.Output($"Stop and remove container: {container.ContainerDisplayName}");

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -338,6 +338,14 @@ namespace GitHub.Runner.Worker
 
             if (!string.IsNullOrEmpty(container.ContainerId))
             {
+                executionContext.Output($"Print container logs: {container.ContainerDisplayName}");
+
+                int logsExitCode = await _dockerManager.DockerLogs(executionContext, container.ContainerId);
+                if (logsExitCode != 0)
+                {
+                    executionContext.Warning($"Docker logs fail with exit code {logsExitCode}");
+                }
+
                 executionContext.Output($"Stop and remove container: {container.ContainerDisplayName}");
 
                 int rmExitCode = await _dockerManager.DockerRemove(executionContext, container.ContainerId);


### PR DESCRIPTION
This will export the service container logs at the end of a GitHub action right before they're torn down. This information can be very useful for debugging, and it's a pain to manually export logs on an as-needed basis.